### PR TITLE
Bsp merge

### DIFF
--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/clothes/hands.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/clothes/hands.mcfunction
@@ -10,6 +10,10 @@ execute if score #custom_resources co_math matches 0 run item replace entity @s 
 execute if score #custom_resources co_math matches 0 run item replace entity @s weapon.offhand with air
 
 # custom hand model
+# 1214
+#$execute if score #custom_resources co_math matches 1 run item replace entity @s weapon.mainhand with nautilus_shell[item_model="minecraft:h$(hands)"] 1
+#$execute if score #custom_resources co_math matches 1 run item replace entity @s weapon.offhand with nautilus_shell[item_model="minecraft:h$(hands)"] 1
 $execute if score #custom_resources co_math matches 1 run item replace entity @s weapon.mainhand with nautilus_shell[custom_model_data=$(hands)] 1
 $execute if score #custom_resources co_math matches 1 run item replace entity @s weapon.offhand with nautilus_shell[custom_model_data=$(hands)] 1
+
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/bind.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/bind.mcfunction
@@ -9,3 +9,10 @@ $data modify storage cooley:statue root.statue_list append value "$(marker)"
 
 # increment length by 1
 function cooley:storage/operation {str:"cooley:statue root.statue_amt",op:"+",mod:1}
+
+# this is a garbage value otherwise
+$data modify storage cooley:statue root.$(marker).timelines_length set value 0
+
+# actor id
+$tag $(marker) add co_actor$(actor)
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/create.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/create.mcfunction
@@ -2,9 +2,16 @@
 # top, bottom, and hands
 # hands used for optional resource pack
 # top + hands / bottom distinction used for lying down poses
+
+# 1214
+#$execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(top_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity)b,Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_top","co_statue_empty","co_despawn"]}
+#$execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(bottom_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity)b,Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_bottom","co_statue_empty","co_despawn"]}
+#$execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(top_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity)b,Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_hands","co_statue_empty","co_despawn"]}
 $execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(top_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity),Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_top","co_statue_empty","co_despawn"]}
 $execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(bottom_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity),Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_bottom","co_statue_empty","co_despawn"]}
 $execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned $(top_offset) run summon armor_stand ~ ~ ~ {NoGravity:$(NoGravity),Invulnerable:1b,NoBasePlate:1b,ShowArms:1b,DisabledSlots:4144959,Tags:["co_statue","co_hands","co_statue_empty","co_despawn"]}
 
 # master marker for one action manipulation
 $execute positioned $(position) rotated as 00030dc6-0-0-0-7 positioned ~ ~ ~ run summon marker ~ ~ ~ {Tags:["co_statue","co_statue_marker","co_statue_empty","co_despawn"]}
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timeline_uuid.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timeline_uuid.mcfunction
@@ -1,0 +1,3 @@
+$data modify storage cooley:statue root.temp.timeline set value "$(data)"
+function cooley:animation/statue/erase_timeline_uuid_compile with storage cooley:statue root.temp
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timeline_uuid_compile.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timeline_uuid_compile.mcfunction
@@ -1,0 +1,5 @@
+# remove a single timeline from the statue
+$data remove storage cooley:statue root.$(uuid).timeline_$(timeline)
+$data remove storage cooley:statue root.$(uuid).timeline_$(timeline)_length
+$data remove storage cooley:statue root.$(uuid).timeline_$(timeline)_object
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timelines_as.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timelines_as.mcfunction
@@ -1,0 +1,8 @@
+# write uuid to temp storage
+function gu:generate
+data modify storage cooley:statue root.temp_stop.uuid set from storage gu:main out
+
+function cooley:animation/statue/erase_timelines_uuid with storage cooley:statue root.temp_stop
+
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timelines_uuid.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/erase_timelines_uuid.mcfunction
@@ -1,0 +1,8 @@
+# loop over timeline
+$data modify storage cooley:statue root.temp.uuid set value "$(uuid)"
+$function cooley:storage/forloop_array {str:"cooley:statue",path:"root.$(uuid).timelines",cmd:"function cooley:animation/statue/erase_timeline_uuid"}
+
+# reset some metadata
+$data remove storage cooley:statue root.$(uuid).timelines
+$data modify storage cooley:statue root.$(uuid).timelines_length set value 0
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/get_uuid_delete.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/get_uuid_delete.mcfunction
@@ -1,8 +1,6 @@
 # get this marker's uuid
 function gu:generate
 data modify storage cooley:statue root.math1 set from storage gu:main out
-#function cooley:storage/print_storage {storage:"gu:main out"}
-#function cooley:storage/print_storage {storage:"cooley:statue root.math1"}
 
 # remove child armor stands
 function cooley:animation/statue/child_uuid_delete with storage cooley:statue root

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/modify.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/modify.mcfunction
@@ -1,5 +1,5 @@
 # data modify rotation is the cleanest way i think
-data modify entity @s Rotation set from storage cooley:statue Rotation
+data modify entity @s Rotation set from storage cooley:statue root.Rotation
 
 # add pose
 $execute at @s rotated as @s run function cooley:animation/statue/pose/$(pose)
@@ -10,8 +10,7 @@ execute as @s[tag=co_top] run function cooley:animation/clothes/top
 execute as @s[tag=co_bottom] run function cooley:animation/clothes/bottom
 $execute as @s[tag=co_hands] run function cooley:animation/clothes/hands {hands:"$(hands)"}
 
-# actor id
-$tag @s add co_actor$(actor)
+
 
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/carry.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/carry.mcfunction
@@ -1,0 +1,3 @@
+data merge entity @s {Pose:{Body:[0.1f,0f,0f],Head:[0.1f,0f,0f],LeftLeg:[-5f,0f,0f],RightLeg:[0.1f,0f,0f],LeftArm:[291f,347f,0f],RightArm:[293f,21f,0f]}}
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/grand.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/grand.mcfunction
@@ -1,0 +1,3 @@
+data merge entity @s {Pose:{Body:[0.1f,0f,0f],Head:[0.1f,0f,0f],LeftLeg:[-5f,0f,0f],RightLeg:[0.1f,0f,0f],LeftArm:[291f,347f,0f],RightArm:[293f,21f,0f]}}
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/lay.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/lay.mcfunction
@@ -1,0 +1,3 @@
+data merge entity @s {Pose:{Body:[273f,0f,0f],Head:[251f,0f,0f],LeftLeg:[255f,7f,9f],RightLeg:[261f,5f,9f],LeftArm:[351f,347f,0f],RightArm:[345f,21f,0f]}}
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/sitting.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose/sitting.mcfunction
@@ -1,3 +1,3 @@
-data merge entity @s {Pose:{Head:[355f,0f,0f],Body:[0.1f,0f,0f],LeftLeg:[309f,349f,0f],RightLeg:[307f,17f,0f],LeftArm:[301f,349f,0f],RightArm:[305f,7f,0f]}}
+data merge entity @s {Pose:{Head:[355f,0f,0f],Body:[0.1f,0f,0f],LeftLeg:[340f,349f,0f],RightLeg:[307f,17f,0f],LeftArm:[301f,349f,0f],RightArm:[305f,7f,0f]}}
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose_offset.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/statue/pose_offset.mcfunction
@@ -1,7 +1,13 @@
+execute if data storage cooley:statue {root:{pose:"warmaster"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
+execute if data storage cooley:statue {root:{pose:"grand"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
+execute if data storage cooley:statue {root:{pose:"smith"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
 execute if data storage cooley:statue {root:{pose:"default"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
 execute if data storage cooley:statue {root:{pose:"sitting"}} run data merge storage cooley:statue {root:{top_offset:"^ ^-0.7 ^-0.20",bottom_offset:"^ ^-0.7 ^-0.17"}}
+execute if data storage cooley:statue {root:{pose:"witch_sit"}} run data merge storage cooley:statue {root:{top_offset:"^ ^-0.8 ^",bottom_offset:"^ ^-0.7 ^-0.17"}}
 execute if data storage cooley:statue {root:{pose:"lean_on_railing"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
 execute if data storage cooley:statue {root:{pose:"sitting_floor"}} run data merge storage cooley:statue {root:{top_offset:"^ ^-0.7 ^-0.20",bottom_offset:"^ ^-0.7 ^-0.17"}}
 execute if data storage cooley:statue {root:{pose:"falling"}} run data merge storage cooley:statue {root:{top_offset:"^ ^-1.3 ^-0.58",bottom_offset:"^ ^-0.7 ^"}}
+execute if data storage cooley:statue {root:{pose:"carry"}} run data merge storage cooley:statue {root:{top_offset:"^ ^ ^",bottom_offset:"^ ^ ^"}}
+execute if data storage cooley:statue {root:{pose:"lay"}} run data merge storage cooley:statue {root:{top_offset:"^ ^-0.225 ^-0.625",bottom_offset:"^ ^0.4 ^"}}
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/find_timeline_index.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/find_timeline_index.mcfunction
@@ -9,5 +9,4 @@ function cooley:storage/strcmp {1:"cooley:statue root.temp.1",2:"cooley:statue r
 
 # if matches, set to 1
 execute if score #strcmp co_math matches 0 run scoreboard players set #find_timeline co_math 1
-#tellraw @a [{"score":{"name": "#strcmp","objective": "co_math"}}]
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/loop.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/loop.mcfunction
@@ -1,4 +1,4 @@
 # loop over statue list
-function cooley:storage/forloop_array {str:"cooley:statue ",path:"root.statue_list",cmd:"function cooley:animation/timeline/process/per_statue"}
+function cooley:storage/forloop_array {str:"cooley:statue",path:"root.statue_list",cmd:"function cooley:animation/timeline/process/per_statue"}
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/child_limb.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/child_limb.mcfunction
@@ -1,6 +1,6 @@
 # update each child armor stand
 # .2 to attempt to prevent weird data bugs TODO more testing for this
-$data modify entity $(head) Pose.$(limb)[$(axis)] set value $(limb_pos).2f
-$data modify entity $(feet) Pose.$(limb)[$(axis)] set value $(limb_pos).2f
-$data modify entity $(hands) Pose.$(limb)[$(axis)] set value $(limb_pos).2f
+$data modify entity $(head) Pose.$(limb)[$(axis)] set value $(limb_pos).0f
+$data modify entity $(feet) Pose.$(limb)[$(axis)] set value $(limb_pos).0f
+$data modify entity $(hands) Pose.$(limb)[$(axis)] set value $(limb_pos).0f
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/get_next.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/get_next.mcfunction
@@ -16,7 +16,7 @@ $scoreboard players set $(uuid)_$(id) co_current_time 0
 #$say reset $(uuid)_$(id)
 
 # run the fsm init for this operation
-$execute as $(uuid) run function cooley:public/fsm/$(fsm)/init
+$execute as $(uuid) at @s rotated as @s run function cooley:public/fsm/$(fsm)/init
 
-
+#$say $(uuid) $(fsm) $(time) $(lerp)
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/object.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/object.mcfunction
@@ -27,7 +27,7 @@ scoreboard players operation #fsm_lerped co_math = #fraction co_math
 # (`#fsm_tick co_math` contains current tick of animation)
 # (`#fsm_unlerped co_math` contains fraction of animation done from 0 to 10000)
 # (`#fsm_lerped co_math` contains fraction of distance traveled from 0 to 10000)
-$execute if score #take_action co_math matches 1 as $(uuid) run function cooley:public/fsm/$(fsm)/tick
+$execute if score #take_action co_math matches 1 as $(uuid) at @s rotated as @s run function cooley:public/fsm/$(fsm)/tick
 
 # get children
 $data modify storage cooley:statue root.temp.head set from storage cooley:statue root.$(uuid)_bind.head
@@ -51,8 +51,8 @@ $execute if score $(uuid)_$(id) co_duration matches -1 unless data storage coole
 # if duration is -2, don't exit
 $execute if score $(uuid)_$(id) co_duration matches -2 run scoreboard players set #object_exit co_math 0
 
-# run the exit function
-$execute if score #object_exit co_math matches 1 as $(uuid) run function cooley:public/fsm/$(fsm)/exit
+# run the exit function only if object still exists
+$execute if score #object_exit co_math matches 1 as $(uuid) if data storage cooley:statue root.$(uuid).timeline_$(id)_object as $(uuid) at @s rotated as @s run function cooley:public/fsm/$(fsm)/exit
 
 # delete this action
 $execute if score #object_exit co_math matches 1 run data remove storage cooley:statue root.$(uuid).timeline_$(id)_object

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/per_statue.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/per_statue.mcfunction
@@ -4,7 +4,8 @@
 $execute as $(data) run function cooley:animation/timeline/process/teleport with storage cooley:statue root.$(data)_bind
 
 $data modify storage cooley:statue root.timeline_check.uuid set value "$(data)"
-$function cooley:storage/forloop_array {str:"cooley:statue ",path:"root.$(data).timelines",cmd:"function cooley:animation/timeline/process/per_timeline"}
+$data modify storage cooley:statue root.temploop set from storage cooley:statue root.$(data).timelines
+function cooley:storage/forloop_array {str:"cooley:statue",path:"root.temploop",cmd:"function cooley:animation/timeline/process/per_timeline"}
 
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/per_timeline.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/per_timeline.mcfunction
@@ -2,4 +2,3 @@
 #$tellraw @a "$(data)"
 $data modify storage cooley:statue root.timeline_check.id set value "$(data)"
 function cooley:animation/timeline/process/get_timeline with storage cooley:statue root.timeline_check
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/update_limb.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/process/update_limb.mcfunction
@@ -1,4 +1,4 @@
-# update each axis, not sure if there's a way to batch this
+# update each axis, not sure if there's a way to batch this TODO
 $function cooley:animation/timeline/process/update_limb_axis {limb:"$(limb)",uuid:"$(uuid)",id:"$(id)",axis:0}
 $function cooley:animation/timeline/process/update_limb_axis {limb:"$(limb)",uuid:"$(uuid)",id:"$(id)",axis:1}
 $function cooley:animation/timeline/process/update_limb_axis {limb:"$(limb)",uuid:"$(uuid)",id:"$(id)",axis:2}

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/push_to_uuid.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/push_to_uuid.mcfunction
@@ -11,7 +11,6 @@ $execute if score #find_timeline co_math matches 0 run data modify storage coole
 # increment length by 1
 $execute if score #find_timeline co_math matches 0 run function cooley:storage/operation {str:"cooley:statue root.$(uuid).timelines_length",op:"+",mod:1}
 
-
 # write the temp to the entity's unique timeline array
 $data modify storage cooley:statue root.$(uuid).timeline_$(timeline_id) append from storage cooley:statue root.temp_block
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/resolve.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/animation/timeline/resolve.mcfunction
@@ -1,4 +1,5 @@
 # causes the object to resolve, instantly triggering the appropriate number of ticks and exit
+# TODO test this, i don't think it actually works
 $data modify storage cooley:statue root.$(marker).timeline_$(timeline)_object.duration set value 0
 
 # calculate loop num

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/as_child.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/as_child.mcfunction
@@ -1,3 +1,4 @@
+# have each child armor stand piece run the function
 function gu:generate
 function cooley:animation/statue/get_children with storage gu:main
 $data modify storage cooley:statue root.temp_child.command set value "$(command)"

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/clear_timeline_as.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/clear_timeline_as.mcfunction
@@ -1,0 +1,7 @@
+# run as the actor to clear its timeline
+# this does not trigger exit effects
+function gu:generate
+data modify storage cooley:combat root.stagger.uuid set from storage gu:main out
+$data modify storage cooley:combat root.stagger.timeline set value $(timeline)
+
+function cooley:animation/statue/erase_timeline_uuid_compile with storage cooley:combat root.stagger

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/create_statue.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/create_statue.mcfunction
@@ -1,7 +1,7 @@
 # generate position offset from pose
 function cooley:animation/statue/pose_offset
 
-# this is not *technically* what sets the statue rotation
+# this is not technically what sets the statue rotation
 # this is just for poses with offsets to know what direction to offset in
 data modify entity 00030dc6-0-0-0-7 Rotation set from storage cooley:statue root.Rotation
 
@@ -13,6 +13,7 @@ function cooley:animation/statue/create with storage cooley:statue root
 execute as @e[type=armor_stand,tag=co_statue_empty] run function cooley:animation/statue/modify with storage cooley:statue root
 
 # pair the pieces and return their uuids
+# this runs @e checks since it's designed to be infrequent
 execute as @e[tag=co_bottom,tag=co_statue_empty] run function gu:generate
 data modify storage cooley:statue root.new.feet set from storage gu:main out
 
@@ -25,6 +26,7 @@ data modify storage cooley:statue root.new.hands set from storage gu:main out
 execute as @e[tag=co_statue_marker,tag=co_statue_empty] run function gu:generate
 data modify storage cooley:statue root.new.marker set from storage gu:main out
 
+data modify storage cooley:statue root.new.actor set from storage cooley:statue root.actor
 function cooley:animation/statue/bind with storage cooley:statue root.new
 
 # finish init

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_all.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_all.mcfunction
@@ -1,4 +1,5 @@
-# clean up storage
+# despawn all actors, kill other despawnables
 execute as @e[type=marker,tag=co_despawn] run function cooley:interface/despawn_as
+execute as @e[type=!marker,tag=co_despawn] run kill @s
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_as.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_as.mcfunction
@@ -1,2 +1,3 @@
+# despawn this actor
 function cooley:animation/statue/get_uuid_delete
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_uuid.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/despawn_uuid.mcfunction
@@ -1,2 +1,3 @@
+# despawn this actor
 $execute as $(uuid) run function cooley:interface/despawn_as
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/resource_disable.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/resource_disable.mcfunction
@@ -1,2 +1,3 @@
+# disable to optional resource pack
 scoreboard players set #custom_resources co_math 0 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/resource_enable.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/resource_enable.mcfunction
@@ -1,2 +1,3 @@
+# enable the optional resource pack
 scoreboard players set #custom_resources co_math 1
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/stop_action_as.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/stop_action_as.mcfunction
@@ -1,7 +1,7 @@
-# write uuid and timeline to temp storage
+# write this actor's uuid and timeline to temp storage
 function gu:generate
 data modify storage cooley:statue root.temp_stop.uuid set from storage gu:main out
 $data modify storage cooley:statue root.temp_stop.timeline set value "$(timeline)"
 
+# repackage this into a uuid call because it's a scoreboard lookup
 function cooley:interface/stop_action_uuid with storage cooley:statue root.temp_stop
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/stop_action_uuid.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/interface/stop_action_uuid.mcfunction
@@ -1,3 +1,3 @@
 # marks the object to be deleted during the next tick and stops it from taking any actions
-#$data modify storage cooley:statue root.$(uuid).timeline_$(timeline)_object.duration set value 0
 $scoreboard players set $(uuid)_$(timeline) co_duration 0
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/load.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/load.mcfunction
@@ -1,9 +1,26 @@
 scoreboard objectives add co_math dummy
+
+# some of these are bsp holdovers TODO remove
 scoreboard objectives add co_current_time dummy
 scoreboard objectives add co_duration dummy
 scoreboard players set 10000 co_math 10000
 scoreboard players set 20000 co_math 20000
 scoreboard players set 1000 co_math 1000
+scoreboard players set 100 co_math 100
+scoreboard players set 398 co_math 398
+
+scoreboard players set 20 co_math 20
+scoreboard players set 60 co_math 60
+scoreboard players set 10 co_math 10
+scoreboard players set 9 co_math 9
+scoreboard players set 8 co_math 8
+scoreboard players set 7 co_math 7
+scoreboard players set 6 co_math 6
+scoreboard players set 5 co_math 5
+scoreboard players set 4 co_math 4
+scoreboard players set 3 co_math 3
+scoreboard players set 2 co_math 2
+scoreboard players set 1 co_math 1
 
 # angle calculator
 # 00030dc6-0-0-0-7
@@ -16,5 +33,7 @@ function cooley:storage/init
 data remove storage gu:main hex_chars
 function gu:zzz/load
 execute unless data storage gu:main hex_chars run tellraw @a [{"text":"gu not installed! Armor Stand Scripting will not function!","color":"#D03030"}]
+
+
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/loop.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/loop.mcfunction
@@ -1,3 +1,5 @@
-scoreboard players set #tracker co_math 0
+# process every actor currently registered
 function cooley:animation/timeline/loop
+
+
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/leather_armor.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/leather_armor.mcfunction
@@ -4,4 +4,3 @@ data modify entity @s ArmorItems[1] set value {count:1, id:"minecraft:leather_le
 data modify entity @s ArmorItems[2] set value {count:1, id:"minecraft:leather_chestplate"}
 
 
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/outfits/player_head_leather_armor.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/outfits/player_head_leather_armor.mcfunction
@@ -17,5 +17,4 @@ function cooley:public/clothes/player_head with storage cooley:statue root.gener
 function cooley:public/clothes/leather_armor
 
 # give wooden sword
-function cooley:public/clothes/wooden_sword
-
+function cooley:public/clothes/iron_ingot

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/outfits/player_head_leather_armor.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/clothes/outfits/player_head_leather_armor.mcfunction
@@ -17,4 +17,4 @@ function cooley:public/clothes/player_head with storage cooley:statue root.gener
 function cooley:public/clothes/leather_armor
 
 # give wooden sword
-function cooley:public/clothes/iron_ingot
+function cooley:public/clothes/wooden_sword

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/README.txt
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/README.txt
@@ -1,3 +1,0 @@
-/event folder may be used for functions that append events to timelines
-
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack1.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack1.mcfunction
@@ -4,32 +4,29 @@
 
 ## raise arm
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:8,lerp:"icbrt"}
+data modify storage cooley:sample root.payload set value {time:6,lerp:"icbrt"}
 data modify storage cooley:sample root.payload.LeftArm set value {values:[0f,-78f,-70f]}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## slash
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:10,lerp:"cbrt"}
+data modify storage cooley:sample root.payload set value {time:8,lerp:"cbrt"}
 data modify storage cooley:sample root.payload.LeftArm set value {values:[165f,-182f,-120f]}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
-#Pose:{Head:[0f,0f,1f],LeftArm:[147f,126f,187f],RightArm:[283f,308f,15f]}}
+
+
 ## minor recovery
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:6,lerp:"icbrt"}
+data modify storage cooley:sample root.payload set value {time:6,lerp:"icbrt",fsm:"slash"}
 data modify storage cooley:sample root.payload.LeftArm set value {values:[147f,-240f,-180f]}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## go back to torso idle afterwards
 # set up the payload (time -1 means it switches as soon as there's another event)
 data modify storage cooley:sample root.payload set value {fsm:"torso_idle"}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack2.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack2.mcfunction
@@ -4,35 +4,34 @@
 
 ## raise arm
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:14,lerp:"icbrt"}
+data modify storage cooley:sample root.payload set value {time:12,lerp:"icbrt"}
 data modify storage cooley:sample root.payload.LeftArm set value {values:[-190f,0f,2f]}
 data modify storage cooley:sample root.payload.RightArm set value {values:[-190f,0f,-20f]}
 data modify storage cooley:sample root.payload.Head set value {values:[-10f,0f,-20f]}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## slash
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:14,lerp:"cbrt"}
-data modify storage cooley:sample root.payload.LeftArm set value {values:[-61f,48f,-16f]}
+data modify storage cooley:sample root.payload set value {time:10,lerp:"cbrt"}
+data modify storage cooley:sample root.payload.LeftArm set value {values:[-49f,17f,-10f]}
 data modify storage cooley:sample root.payload.RightArm set value {values:[-63f,0f,15f]}
 data modify storage cooley:sample root.payload.Head set value {values:[2f,0f,0f]}
+# request an addition to the timeline
+function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## minor recovery
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:10,lerp:"icbrt"}
-data modify storage cooley:sample root.payload.LeftArm set value {values:[-30f,10f,10f]}
-data modify storage cooley:sample root.payload.RightArm set value {values:[-33f,0f,-10f]}
+data modify storage cooley:sample root.payload set value {time:9,lerp:"icbrt",fsm:"smash"}
+data modify storage cooley:sample root.payload.LeftArm set value {values:[10f,10f,10f]}
+data modify storage cooley:sample root.payload.RightArm set value {values:[0f,0f,-10f]}
 data modify storage cooley:sample root.payload.Head set value {values:[2f,0f,0f]}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## go back to torso idle afterwards
 # set up the payload (time -1 means it switches as soon as there's another event)
 data modify storage cooley:sample root.payload set value {fsm:"torso_idle"}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack3.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/attack3.mcfunction
@@ -1,28 +1,35 @@
-# full sword slash animation
-
-# appends the torso_idle fsm to timeline as body default
-
-## raise arm
+## jump
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:8,lerp:"icbrt"}
-data modify storage cooley:sample root.payload.LeftArm set value {values:[0f,-78f,-70f]}
-
+data modify storage cooley:sample root.payload set value {time:12,lerp:"icbrt",fsm:"jump"}
+data modify storage cooley:sample root.payload.LeftArm set value {values:[-90f,-50f,0f]}
+data modify storage cooley:sample root.payload.RightArm set value {values:[-95f,60f,0f]}
+data modify storage cooley:sample root.payload.LeftLeg set value {values:[-13f,-23f,0f]}
+data modify storage cooley:sample root.payload.RightLeg set value {values:[-15f,31f,0f]}
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
-## slash
+## slam
 # set up the payload
-data modify storage cooley:sample root.payload set value {time:10,lerp:"cbrt"}
-data modify storage cooley:sample root.payload.LeftArm set value {values:[165f,-182f,-120f]}
+data modify storage cooley:sample root.payload set value {time:12,lerp:"cbrt",fsm:"fall"}
+data modify storage cooley:sample root.payload.LeftArm set value {values:[-30f,-31f,0f]}
+data modify storage cooley:sample root.payload.RightArm set value {values:[-35f,20f,0f]}
+data modify storage cooley:sample root.payload.LeftLeg set value {values:[-13f,-23f,0f]}
+data modify storage cooley:sample root.payload.RightLeg set value {values:[-15f,31f,0f]}
+# request an addition to the timeline
+function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
+## recovery
+# set up the payload
+data modify storage cooley:sample root.payload set value {time:8,lerp:"cbrt",fsm:"slam"}
+data modify storage cooley:sample root.payload.LeftArm set value {values:[-11f,-5f,0f]}
+data modify storage cooley:sample root.payload.RightArm set value {values:[-7f,4f,0f]}
+data modify storage cooley:sample root.payload.LeftLeg set value {values:[-5f,-2f,0f]}
+data modify storage cooley:sample root.payload.RightLeg set value {values:[-4f,0f,0f]}
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
 
 ## go back to torso idle afterwards
 # set up the payload (time -1 means it switches as soon as there's another event)
 data modify storage cooley:sample root.payload set value {fsm:"torso_idle"}
-
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:2}
-
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/walk_cycle1.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/walk_cycle1.mcfunction
@@ -1,4 +1,5 @@
 ## move limbs in opposite directions
+
 # set up the payload
 data modify storage cooley:sample root.payload set value {time:15,fsm:"walk_cycle1",lerp:"cbrt"}
 data modify storage cooley:sample root.payload.LeftLeg set value {values:[-20f,0f,1f]}
@@ -14,4 +15,9 @@ data modify storage cooley:sample root.payload.RightArm set value {values:[-20f,
 
 # request an addition to the timeline
 function cooley:interface/add_action {storage:"cooley:sample root.payload",timeline:0}
+
+
+
+
+
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/walk_cycle2.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/event/walk_cycle2.mcfunction
@@ -1,4 +1,5 @@
 ## move limbs in opposite directions
+
 # set up the payload
 data modify storage cooley:sample root.payload set value {time:15,fsm:"walk_cycle2",lerp:"cbrt"}
 data modify storage cooley:sample root.payload.LeftLeg set value {values:[20f,0f,1f]}

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/README.txt
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/README.txt
@@ -1,3 +1,0 @@
-/interface folder may be used for functions intended to be run from console
-
-

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/delete_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/delete_walking.mcfunction
@@ -1,6 +1,7 @@
 # grab the first uuid from the walker storage and feed it into the despawner
-data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.walking_statue.uuid[0]
-data remove storage cooley:sample root.walking_statue.uuid[0]
+#data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.walking_statue.uuid[0]
+#data remove storage cooley:sample root.walking_statue.uuid[0]
+data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.boss.uuid
+data remove storage cooley:sample root.boss.uuid
 function cooley:interface/despawn_uuid with storage cooley:sample root.temp
-
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/delete_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/delete_walking.mcfunction
@@ -1,7 +1,5 @@
-# grab the first uuid from the walker storage and feed it into the despawner
-#data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.walking_statue.uuid[0]
-#data remove storage cooley:sample root.walking_statue.uuid[0]
-data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.boss.uuid
-data remove storage cooley:sample root.boss.uuid
+# grab the first uuid from the storage and feed it into the despawner
+data modify storage cooley:sample root.temp.uuid set from storage cooley:sample root.boss.uuid[0]
+data remove storage cooley:sample root.boss.uuid[0]
 function cooley:interface/despawn_uuid with storage cooley:sample root.temp
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/summon_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/summon_walking.mcfunction
@@ -1,4 +1,4 @@
 # check if there's already a boss
-execute unless data storage cooley:sample root.boss.uuid run function cooley:public/sample/summon_boss
+function cooley:public/sample/summon_boss
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/summon_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/interface/summon_walking.mcfunction
@@ -1,10 +1,4 @@
-# payload of information for the armor stand
-data modify storage cooley:statue root merge value {position:"0.5 -60.0 0.5",clothes:"player_head_leather_armor",hands:2}
-# request creation of armor stand
-function cooley:interface/create_statue
-
-# use cooley:statue root.new.marker to reference the newly created statue
-# tip: saving this uuid makes it easier to reference it in the future
-function cooley:public/sample/populate_walking with storage cooley:statue root.new
+# check if there's already a boss
+execute unless data storage cooley:sample root.boss.uuid run function cooley:public/sample/summon_boss
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/populate_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/populate_walking.mcfunction
@@ -2,8 +2,13 @@
 $execute as $(marker) run function cooley:public/sample/event/walk_cycle1
 $execute as $(marker) run function cooley:public/sample/event/torso_idle
 
+# save boss uuid
+$data modify storage cooley:sample root.boss.uuid set value "$(marker)"
+
+
 # save uuid for later
 # systems that create an arbitrary number of statues will
 # need a robust way of storing their uuids. adding to another array allows
 # for sequential single deletes in this case
-$data modify storage cooley:sample root.walking_statue.uuid append value "$(marker)"
+#$data modify storage cooley:sample root.walking_statue.uuid append value "$(marker)"
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/populate_walking.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/populate_walking.mcfunction
@@ -2,13 +2,6 @@
 $execute as $(marker) run function cooley:public/sample/event/walk_cycle1
 $execute as $(marker) run function cooley:public/sample/event/torso_idle
 
-# save boss uuid
-$data modify storage cooley:sample root.boss.uuid set value "$(marker)"
-
-
-# save uuid for later
-# systems that create an arbitrary number of statues will
-# need a robust way of storing their uuids. adding to another array allows
-# for sequential single deletes in this case
-#$data modify storage cooley:sample root.walking_statue.uuid append value "$(marker)"
+# save uuid
+$data modify storage cooley:sample root.boss.uuid append value "$(marker)"
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/rand_attack.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/rand_attack.mcfunction
@@ -1,5 +1,6 @@
 # generate a random attack from boss moveset
-execute store result storage cooley:sample root.random int 1 run random value 1..2
+#execute store result storage cooley:sample root.random int 1 run random value 1..4
+data modify storage cooley:sample root.random set value 1
 
 function cooley:public/sample/choose_attack with storage cooley:sample root
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/summon_boss.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/summon_boss.mcfunction
@@ -1,5 +1,5 @@
 # payload of information for the armor stand
-data modify storage cooley:statue root merge value {position:"-40.5 -3.0 139.5",clothes:"player_head_leather_armor",hands:2,Rotation:[-90.0f,40.0f]}
+data modify storage cooley:statue root merge value {position:"-2.26 -60.00 0.94",clothes:"player_head_leather_armor",hands:2,Rotation:[-90.0f,40.0f]}
 # request creation of armor stand
 function cooley:interface/create_statue
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/summon_boss.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/summon_boss.mcfunction
@@ -1,0 +1,10 @@
+# payload of information for the armor stand
+data modify storage cooley:statue root merge value {position:"-40.5 -3.0 139.5",clothes:"player_head_leather_armor",hands:2,Rotation:[-90.0f,40.0f]}
+# request creation of armor stand
+function cooley:interface/create_statue
+
+# use cooley:statue root.new.marker to reference the newly created statue
+# tip: saving this uuid makes it easier to reference it in the future
+function cooley:public/sample/populate_walking with storage cooley:statue root.new
+
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/walk.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/public/sample/walk.mcfunction
@@ -1,9 +1,6 @@
-#execute at @s facing entity @p feet run tp @s ~ ~ ~ ~ ~
-#scoreboard players set @s co_send 2
-#execute at @s unless entity @p[distance=..1] run function motion:motion/push
-
-# doesn't seem to be a performance diff here
-execute at @s unless entity @p[distance=..1] facing entity @p feet run tp @s ^ ^ ^0.2 ~ ~
+# move towards player if far away
+execute at @s unless entity @p[distance=..2.8] facing entity @p feet run tp @s ^ ^ ^0.2 ~ ~
+execute at @s if entity @p[distance=..2.8] facing entity @p feet run tp @s ^ ^ ^ ~ ~
 
 
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/forloop_array.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/forloop_array.mcfunction
@@ -2,18 +2,20 @@
 
 # get data from slot 0
 data modify storage cooley:storage root.forloop_array.data set value {}
-$data modify storage cooley:storage root.forloop_array.data.data set from storage $(str)$(path)[0]
+$data modify storage cooley:storage root.forloop_array.data.data set from storage $(str) $(path)[0]
+#$say data modify storage cooley:storage root.forloop_array.data.data set from storage $(str) $(path)[0]
 
 # if an element was found, run the command with the contents (use $(data))
 $execute if data storage cooley:storage root.forloop_array.data.data run $(cmd) with storage cooley:storage root.forloop_array.data
 
+
 # allows nested for loops be rewriting the data
 data modify storage cooley:storage root.forloop_array.data set value {}
-$data modify storage cooley:storage root.forloop_array.data.data set from storage $(str)$(path)[0]
+$data modify storage cooley:storage root.forloop_array.data.data set from storage $(str) $(path)[0]
 
 # save element for later, remove it from array
 $execute if data storage cooley:storage root.forloop_array.data.data run data modify storage cooley:storage root.forloop_array.data_storage$(path) append from storage cooley:storage root.forloop_array.data.data
-$execute if data storage cooley:storage root.forloop_array.data.data run data remove storage $(str)$(path)[0]
+$execute if data storage cooley:storage root.forloop_array.data.data run data remove storage $(str) $(path)[0]
 
 # recurse
 $execute if data storage cooley:storage root.forloop_array.data.data run function cooley:storage/forloop_array {str:"$(str)",path:"$(path)",cmd:"$(cmd)"}
@@ -24,7 +26,6 @@ data modify storage cooley:storage root.forloop_array.data set value {}
 $data modify storage cooley:storage root.forloop_array.data.data set from storage cooley:storage root.forloop_array.data_storage$(path)[0]
 
 # put it into original array
-$execute if data storage cooley:storage root.forloop_array.data.data run data modify storage $(str)$(path) append from storage cooley:storage root.forloop_array.data.data
+$execute if data storage cooley:storage root.forloop_array.data.data run data modify storage $(str) $(path) append from storage cooley:storage root.forloop_array.data.data
 $execute if data storage cooley:storage root.forloop_array.data.data run data remove storage cooley:storage root.forloop_array.data_storage$(path)[0]
-
 

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/print.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/print.mcfunction
@@ -1,1 +1,2 @@
-$tellraw @a "message content: $(message)"
+$say message content: $(message)
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/print_storage.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/print_storage.mcfunction
@@ -1,2 +1,4 @@
 $data modify storage cooley:storage root.temp.message set from storage $(storage)
+#$say data modify storage cooley:storage root.temp.message set from storage $(storage)
 function cooley:storage/print with storage cooley:storage root.temp
+

--- a/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/strcmp.mcfunction
+++ b/Armor Stand Scripting [1.21.3]/data/cooley/function/storage/strcmp.mcfunction
@@ -5,4 +5,3 @@ $data modify storage cooley:storage root.strtemp set from storage $(1)
 $execute store success score #strcmp co_math run data modify storage cooley:storage root.strtemp set from storage $(2)
 
 #$tellraw @a "$(1), $(2)"
-

--- a/Armor Stand Scripting [1.21.3]/data/minecraft/tags/function/load.json
+++ b/Armor Stand Scripting [1.21.3]/data/minecraft/tags/function/load.json
@@ -1,6 +1,5 @@
-{ 
-	"replace":false,
-	"values": [ 
-		"cooley:load" 
-	]
+{
+    "values" : [
+        "cooley:load"
+    ]
 }

--- a/Armor Stand Scripting [1.21.3]/data/minecraft/tags/function/tick.json
+++ b/Armor Stand Scripting [1.21.3]/data/minecraft/tags/function/tick.json
@@ -1,7 +1,5 @@
 {
-	"replace":false,
-	"values": [
-		"cooley:loop"
-	]
-
+    "values" : [
+        "cooley:loop"
+    ]
 }


### PR DESCRIPTION
Ported over a bunch of fixes that were in bsp but not in the main repo:
- For-each loops break when the array is modified mid-execution. That still happens but crass works around it now.
- Actor ids are now assigned to markers rather than their child parts.
- It is now possible to clear a specific timeline from an actor with `clear_timeline_as`.